### PR TITLE
Choosing the base URI of UMLS Semantic Types

### DIFF
--- a/conf_sample.py
+++ b/conf_sample.py
@@ -9,3 +9,4 @@ DB_PASS = "your db pass"
 
 UMLS_VERSION = "2011ab"
 
+UMLS_BASE_URI = "http://purl.bioontology.org/ontology/"

--- a/umls2rdf.py
+++ b/umls2rdf.py
@@ -83,7 +83,7 @@ MRSTY_TUI = 1
 MRSAB_LAT = 19
 
 def get_umls_url(code):
-    return "http://purl.bioontology.org/ontology/%s/"%code
+    return "%s%s/"%(conf.UMLS_BASE_URI,code)
 
 def flatten(matrix):
     return reduce(lambda x,y: x+y,matrix)


### PR DESCRIPTION
To be able to choose the base URI of the URI pointing to UMLS semantic type (the umls:hasSTY property in the resulting RDF)